### PR TITLE
feat: 新增自定义获取图标 API 的设置项

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -108,6 +108,7 @@ const DEFAULT_CONFIGS = {
     "site.customCss": "",
     "site.backgroundImage": "", // 背景图片URL
     "site.backgroundOpacity": "0.15", // 背景蒙版透明度
+    "site.iconApi": "https://www.faviconextractor.com/favicon/{domain}?larger=true", // 默认使用的API接口，带上 ?larger=true 参数可以获取最大尺寸的图标
 };
 
 function App() {
@@ -1194,6 +1195,7 @@ function App() {
                                             onAddSite={handleOpenAddSite}
                                             onUpdateGroup={handleGroupUpdate}
                                             onDeleteGroup={handleGroupDelete}
+                                            configs={configs}
                                         />
                                     ))}
                                 </Stack>
@@ -1340,7 +1342,8 @@ function App() {
                                                         }
                                                         const domain = extractDomain(newSite.url);
                                                         if (domain) {
-                                                            const iconUrl = `https://www.faviconextractor.com/favicon/${domain}`;
+                                                            const actualIconApi = configs["site.iconApi"] || "https://www.faviconextractor.com/favicon/{domain}?larger=true";
+                                                            const iconUrl = actualIconApi.replace("{domain}", domain);
                                                             setNewSite({
                                                                 ...newSite,
                                                                 icon: iconUrl
@@ -1449,6 +1452,25 @@ function App() {
                                     value={tempConfigs["site.name"]}
                                     onChange={handleConfigInputChange}
                                 />
+                                {/* 获取图标API设置项 */}
+                                <Box sx={{ mb: 1 }}>
+                                    <Typography variant="subtitle1" gutterBottom>
+                                        获取图标API设置
+                                    </Typography>
+                                    <TextField
+                                        margin='dense'
+                                        id='site-icon-api'
+                                        name='site.iconApi'
+                                        label='获取图标API URL'
+                                        type='text'
+                                        fullWidth
+                                        variant='outlined'
+                                        value={tempConfigs["site.iconApi"]}
+                                        onChange={handleConfigInputChange}
+                                        placeholder='https://example.com/favicon/{domain}'
+                                        helperText='输入获取图标API的地址，使用 {domain} 作为域名占位符'
+                                    />
+                                </Box>
                                 {/* 新增背景图片设置 */}
                                 <Box sx={{ mb: 1 }}>
                                     <Typography variant="subtitle1" gutterBottom>
@@ -1639,3 +1661,4 @@ function App() {
 }
 
 export default App;
+ 

--- a/src/components/GroupCard.tsx
+++ b/src/components/GroupCard.tsx
@@ -40,6 +40,7 @@ interface GroupCardProps {
     onAddSite?: (groupId: number) => void; // 新增添加卡片的可选回调函数
     onUpdateGroup?: (group: Group) => void; // 更新分组的回调函数
     onDeleteGroup?: (groupId: number) => void; // 删除分组的回调函数
+    configs?: Record<string, string>; // 传入配置
 }
 
 const GroupCard: React.FC<GroupCardProps> = ({
@@ -53,6 +54,7 @@ const GroupCard: React.FC<GroupCardProps> = ({
     onAddSite,
     onUpdateGroup,
     onDeleteGroup,
+    configs,
 }) => {
     // 添加本地状态来管理站点排序
     const [sites, setSites] = useState<Site[]>(group.sites);
@@ -191,6 +193,7 @@ const GroupCard: React.FC<GroupCardProps> = ({
                                             onDelete={onDelete}
                                             isEditMode={true}
                                             index={idx}
+                                            iconApi={configs?.["site.iconApi"]} // 传入iconApi配置
                                         />
                                     </Box>
                                 ))}
@@ -230,6 +233,7 @@ const GroupCard: React.FC<GroupCardProps> = ({
                             onUpdate={onUpdate}
                             onDelete={onDelete}
                             isEditMode={false}
+                            iconApi={configs?.["site.iconApi"]} // 传入iconApi配置
                         />
                     </Box>
                 ))}

--- a/src/components/SiteCard.tsx
+++ b/src/components/SiteCard.tsx
@@ -24,6 +24,7 @@ interface SiteCardProps {
     onDelete: (siteId: number) => void;
     isEditMode?: boolean;
     index?: number;
+    iconApi?: string; // 添加iconApi属性
 }
 
 // 使用memo包装组件以减少不必要的重渲染
@@ -33,6 +34,7 @@ const SiteCard = memo(function SiteCard({
     onDelete,
     isEditMode = false,
     index = 0,
+    iconApi, // 添加iconApi参数
 }: SiteCardProps) {
     const [showSettings, setShowSettings] = useState(false);
     const [iconError, setIconError] = useState(!site.icon);
@@ -341,6 +343,7 @@ const SiteCard = memo(function SiteCard({
                         onUpdate={onUpdate}
                         onDelete={onDelete}
                         onClose={handleCloseSettings}
+                        iconApi={iconApi} // 传递iconApi给SiteSettingsModal
                     />
                 )}
             </>
@@ -357,6 +360,7 @@ const SiteCard = memo(function SiteCard({
                     onUpdate={onUpdate}
                     onDelete={onDelete}
                     onClose={handleCloseSettings}
+                    iconApi={iconApi} // 传递iconApi给SiteSettingsModal
                 />
             )}
         </>

--- a/src/components/SiteSettingsModal.tsx
+++ b/src/components/SiteSettingsModal.tsx
@@ -21,11 +21,13 @@ import {
     Avatar,
     useTheme,
     SelectChangeEvent,
+    InputAdornment,
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
 import DeleteIcon from "@mui/icons-material/Delete";
 import SaveIcon from "@mui/icons-material/Save";
 import CancelIcon from "@mui/icons-material/Cancel";
+import AutoFixHighIcon from "@mui/icons-material/AutoFixHigh";
 
 interface SiteSettingsModalProps {
     site: Site;
@@ -33,6 +35,26 @@ interface SiteSettingsModalProps {
     onDelete: (siteId: number) => void;
     onClose: () => void;
     groups?: Group[]; // 可选的分组列表
+    iconApi?: string; // 图标API配置
+}
+
+// 辅助函数：提取域名
+function extractDomain(url: string): string | null {
+  if (!url) return null;
+  
+  try {
+      // 尝试自动添加协议头，如果缺少的话
+      let fullUrl = url;
+      if (!/^https?:\/\//i.test(url)) {
+          fullUrl = 'http://' + url;
+      }
+      const parsedUrl = new URL(fullUrl);
+      return parsedUrl.hostname;
+  } catch (e) {
+      // 尝试备用方法
+      const match = url.match(/^(?:https?:\/\/)?(?:[^@\n]+@)?(?:www\.)?([^:\/\n?]+)/im);
+      return match && match[1] ? match[1] : url;
+  }
 }
 
 export default function SiteSettingsModal({
@@ -41,6 +63,7 @@ export default function SiteSettingsModal({
     onDelete,
     onClose,
     groups = [],
+    iconApi = "https://www.faviconextractor.com/favicon/{domain}?larger=true",
 }: SiteSettingsModalProps) {
     const theme = useTheme();
 
@@ -245,6 +268,36 @@ export default function SiteSettingsModal({
                                     placeholder='https://example.com/icon.png'
                                     variant='outlined'
                                     size='small'
+                                    InputProps={{
+                                        endAdornment: (
+                                            <InputAdornment position="end">
+                                                <IconButton
+                                                    onClick={() => {
+                                                        if (!formData.url) {
+                                                            // handleError("请先输入站点URL");
+                                                            return;
+                                                        }
+                                                        const domain = extractDomain(formData.url);
+                                                        if (domain) {
+                                                            const actualIconApi = iconApi || "https://www.faviconextractor.com/favicon/{domain}?larger=true";
+                                                            const iconUrl = actualIconApi.replace("{domain}", domain);
+                                                            setFormData(prev => ({
+                                                                ...prev,
+                                                                icon: iconUrl
+                                                            }));
+                                                            setIconPreview(iconUrl);
+                                                        } else {
+                                                            // handleError("无法从URL中获取域名");
+                                                        }
+                                                    }}
+                                                    edge="end"
+                                                    title="自动获取图标"
+                                                >
+                                                    <AutoFixHighIcon />
+                                                </IconButton>
+                                            </InputAdornment>
+                                        ),
+                                    }}
                                 />
                             </Box>
                         </Box>


### PR DESCRIPTION
新增支持使用自定义获取图标的接口设置项

网站设置页面
![开发演示站-04-18-2025_02_31_AM](https://github.com/user-attachments/assets/baa58d0e-4639-4d62-938b-bda93dde7df2)

编辑站点页面
![开发演示站-04-18-2025_02_33_AM](https://github.com/user-attachments/assets/63e60a2e-82b2-4607-a764-550a7bf39a60)

所有代码和功能，已经过测试，请放心~~食用~~

**演示站**
地址：[点此访问](https://navihive.aun.workers.dev/)
账号：admin
密码：123456

**以下接口，已经过测试**
* `https://www.faviconextractor.com/favicon/{domain}`
* `https://www.faviconextractor.com/favicon/{domain}?larger=true`
* `https://www.google.com/s2/favicons?domain={domain}`
* `https://www.google.com/s2/favicons?domain={domain}&sz=64`
* `https://favicons.fuzqing.workers.dev/api/getFavicon?url={domain}`
* `https://favicons.fuzqing.workers.dev/api/getFavicon?url={domain}&size=64`

**其它接口请自测**